### PR TITLE
Ensure that a job retains its priority when it is rescheduled. 

### DIFF
--- a/tests/TreeHouse/WorkerBundle/QueueManagerTest.php
+++ b/tests/TreeHouse/WorkerBundle/QueueManagerTest.php
@@ -322,6 +322,22 @@ class QueueManagerTest extends \PHPUnit_Framework_TestCase
         $this->manager->reschedule($job, $date);
     }
 
+    public function testRescheduleWithPriority()
+    {
+        $delay = 10;
+        $date  = new \DateTime(sprintf('+ %d seconds', $delay));
+        $job   = new Job(1234, 'data');
+        $priority = PheanstalkInterface::DEFAULT_PRIORITY - 1;
+
+        $this->pheanstalk
+            ->expects($this->once())
+            ->method('release')
+            ->with($job, $priority, $delay)
+        ;
+
+        $this->manager->reschedule($job, $date, $priority);
+    }
+
     /**
      * @expectedException        \InvalidArgumentException
      * @expectedExceptionMessage You cannot reschedule a job in the past

--- a/tests/TreeHouse/WorkerBundle/QueueManagerTest.php
+++ b/tests/TreeHouse/WorkerBundle/QueueManagerTest.php
@@ -635,6 +635,7 @@ class QueueManagerTest extends \PHPUnit_Framework_TestCase
         $stats = [
             'tube'     => $action,
             'releases' => 0,
+            'pri'      => PheanstalkInterface::DEFAULT_PRIORITY,
         ];
 
         $this->pheanstalk
@@ -688,6 +689,7 @@ class QueueManagerTest extends \PHPUnit_Framework_TestCase
         $stats = [
             'tube'     => $action,
             'releases' => 0,
+            'pri'      => PheanstalkInterface::DEFAULT_PRIORITY,
         ];
 
         $this->pheanstalk
@@ -727,6 +729,7 @@ class QueueManagerTest extends \PHPUnit_Framework_TestCase
         $stats = [
             'tube'     => $action,
             'releases' => 0,
+            'pri'      => PheanstalkInterface::DEFAULT_PRIORITY,
         ];
 
         $this->pheanstalk
@@ -757,6 +760,7 @@ class QueueManagerTest extends \PHPUnit_Framework_TestCase
         $stats = [
             'tube'     => $action,
             'releases' => 0,
+            'pri'      => PheanstalkInterface::DEFAULT_PRIORITY,
         ];
 
         $this->pheanstalk
@@ -793,6 +797,7 @@ class QueueManagerTest extends \PHPUnit_Framework_TestCase
         $stats = [
             'tube'     => $action,
             'releases' => 2,
+            'pri'      => PheanstalkInterface::DEFAULT_PRIORITY,
         ];
 
         $this->pheanstalk


### PR DESCRIPTION
Currently when a job throws a RescheduleException the priority of the original job is replaced by PheanstalkInterface::DEFAULT_PRIORITY=1024 in the delayed queue. 

This means that delayed low priority jobs can appear to jump to a higher priority when their delay is over. It also means that high priority jobs can get stuck behind low priority jobs when they return from the delayed queue.

I don't believe that this is intentional behaviour. This PR changes it so that the priority from the original job is carried through to the delayed queue. 

I have added a test which I think will test that this is true, but unfortunately I've been unable to figure out how to run the tests. 
