### PR TITLE
Add ability to specify a new priority on rescheduled jobs.

### DIFF
--- a/src/TreeHouse/WorkerBundle/Exception/RescheduleException.php
+++ b/src/TreeHouse/WorkerBundle/Exception/RescheduleException.php
@@ -15,6 +15,11 @@ class RescheduleException extends \Exception
     private $rescheduleMessage;
 
     /**
+     * @var integer
+     */
+    private $reshedulePriority;
+
+    /**
      * @param \DateTime $date
      */
     public function setRescheduleDate(\DateTime $date)
@@ -53,14 +58,33 @@ class RescheduleException extends \Exception
      *                     Can be anything that strtotime accepts, without the `+` sign, eg: '10 seconds'
      * @param string $msg
      *
+     * @param integer $newPriority A new priority to apply the the job. If omitted the current priority will be used.
+     *
      * @return RescheduleException
      */
-    public static function create($time, $msg = null)
+    public static function create($time, $msg = null, $newPriority = null)
     {
         $re = new RescheduleException($msg);
         $re->setRescheduleDate(new \DateTime('@' . strtotime('+' . $time)));
         $re->setRescheduleMessage($msg);
+        $re->setReshedulePriority($newPriority);
 
         return $re;
+    }
+
+    /**
+     * @return integer
+     */
+    public function getReshedulePriority()
+    {
+        return $this->reshedulePriority;
+    }
+
+    /**
+     * @param integer $reshedulePriority
+     */
+    public function setReshedulePriority($reshedulePriority)
+    {
+        $this->reshedulePriority = $reshedulePriority;
     }
 }

--- a/src/TreeHouse/WorkerBundle/QueueManager.php
+++ b/src/TreeHouse/WorkerBundle/QueueManager.php
@@ -508,6 +508,10 @@ class QueueManager
 
             return $result;
         } catch (RescheduleException $re) {
+            // Override priority if the RescheduleException provides a new one.
+            if (!is_null($re->getReshedulePriority())) {
+                $priority = $re->getReshedulePriority();
+            }
             // reschedule the job
             $this->reschedule($job, $re->getRescheduleDate(), $priority);
         } catch (AbortException $e) {


### PR DESCRIPTION
This PR adds the ability to set a new priority in addition to a delay when throwing a ResheduleException. 

Usage example:
`throw RescheduleException::create("120 seconds", null, 1023);`

Will put the job on the delay queue for 120 seconds with a priority of 1023 when it returns to the ready queue. 