### PR TITLE
Catch throwables / reschedule or bury

### DIFF
--- a/src/TreeHouse/WorkerBundle/QueueManager.php
+++ b/src/TreeHouse/WorkerBundle/QueueManager.php
@@ -517,7 +517,7 @@ class QueueManager
         } catch (AbortException $e) {
             // abort thrown from executor, rethrow it and let the caller handle it
             throw $e;
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             // some other exception occured
             $message = sprintf('Exception occurred: %s in %s on line %d', $e->getMessage(), $e->getFile(), $e->getLine());
             $this->logJob($job->getId(), $message, LogLevel::ERROR, $context);

--- a/tests/TreeHouse/WorkerBundle/Tests/Executor/FatalErrorExecutor.php
+++ b/tests/TreeHouse/WorkerBundle/Tests/Executor/FatalErrorExecutor.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace TreeHouse\WorkerBundle\Tests\Executor;
+
+use Symfony\Component\OptionsResolver\Exception\ExceptionInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use TreeHouse\WorkerBundle\Executor\ExecutorInterface;
+
+class FatalErrorExecutor implements ExecutorInterface
+{
+
+    /**
+     * The name of this executor, corresponds directly with a tube name.
+     * The naming convention is the same as that of services and events, ie:
+     * lowercased, separated by periods, eg: `entity.update`.
+     *
+     * @return string
+     */
+    public function getName()
+    {
+        return 'fatal.error';
+    }
+
+    /**
+     * Executes a job with given payload.
+     *
+     * @param array $payload
+     *
+     * @return mixed
+     */
+    public function execute(array $payload)
+    {
+        throw new \Error('Fatal error');
+    }
+
+    /**
+     * Configures the payload for this executor.
+     * You can throw an optionsresolver exception if an invalid payload is
+     * given to a job, in which case the job will be deleted.
+     *
+     * @param OptionsResolver $resolver
+     *
+     * @throws ExceptionInterface
+     */
+    public function configurePayload(OptionsResolver $resolver)
+    {
+
+    }
+}


### PR DESCRIPTION
If a fatal error occurs on a worker, this code will not catch the exception. Use \Throwable for also reschedule or bury jobs with fatal aborts in executor.