### PR TITLE
Custom Reschedule Time

### DIFF
--- a/src/TreeHouse/WorkerBundle/QueueManager.php
+++ b/src/TreeHouse/WorkerBundle/QueueManager.php
@@ -196,13 +196,14 @@ class QueueManager
      *                             string relative from now, like "10 seconds".
      * @param int        $priority From 0 (most urgent) to 0xFFFFFFFF (least urgent)
      * @param int        $ttr      Time To Run: seconds a job can be reserved for
+     * @param string     $rescheduleAfter how much delay should the reschedule have on error
      *
      * @throws \InvalidArgumentException When the action is not defined
      * @throws \InvalidArgumentException When `$delay` or `$priority` is negative
      *
      * @return int The job id
      */
-    public function add($action, array $payload, $delay = null, $priority = null, $ttr = null, $reScheduleTime = null)
+    public function add($action, array $payload, $delay = null, $priority = null, $ttr = null, $rescheduleAfter = null)
     {
         if (false === $this->hasExecutor($action)) {
             throw new \InvalidArgumentException(sprintf(
@@ -226,9 +227,9 @@ class QueueManager
         if(isset($payload['__rescheduleTime'])){
             throw new \InvalidArgumentException('__rescheduleTime is reserved in payload');
         }
-        if (null === $reScheduleTime) {
-            $reScheduleTime =  PheanstalkInterface::DEFAULT_RESCHEDULE_TIME;
-            $payload['__rescheduleTime'] = $reScheduleTime;
+        if (null === $rescheduleAfter) {
+            $rescheduleAfter =  '10min';
+            $payload['__rescheduleTime'] = $rescheduleAfter;
         }
 
         if (!is_numeric($delay)) {

--- a/src/TreeHouse/WorkerBundle/QueueManager.php
+++ b/src/TreeHouse/WorkerBundle/QueueManager.php
@@ -500,11 +500,8 @@ class QueueManager
         $payload  = (array) json_decode($job->getData(), true);
         $releases = intval($stats['releases']);
         $priority = intval($stats['pri']);
-        $rescheduleTime =  PheanstalkInterface::DEFAULT_RESCHEDULE_TIME;
-        if(isset($payload['__rescheduleTime'])){
-            $rescheduleTime = $payload['__rescheduleTime'] ;
-            unset($payload['__rescheduleTime']);
-        }
+        $rescheduleTime = $payload['__rescheduleTime'];
+        unset($payload['__rescheduleTime']);
 
         // context for logging
         $context = [

--- a/tests/TreeHouse/WorkerBundle/QueueManagerTest.php
+++ b/tests/TreeHouse/WorkerBundle/QueueManagerTest.php
@@ -148,7 +148,7 @@ class QueueManagerTest extends TestCase
 
         $payload = ['data'];
         $expectedPayload = $payload;
-        $expectedPayload['__rescheduleTime'] = PheanstalkInterface::DEFAULT_RESCHEDULE_TIME;
+        $expectedPayload['__rescheduleTime'] = '10min';
 
         $this->pheanstalk
             ->expects($this->once())
@@ -174,7 +174,7 @@ class QueueManagerTest extends TestCase
         $ttr      = 1200;
         $rescheduleTime = '60min';
         $expectedPayload = $payload;
-        $expectedPayload['__rescheduleTime'] = '60min';
+        $expectedPayload['__rescheduleTime'] = '10min';
 
         $this->pheanstalk
             ->expects($this->once())

--- a/tests/TreeHouse/WorkerBundle/QueueManagerTest.php
+++ b/tests/TreeHouse/WorkerBundle/QueueManagerTest.php
@@ -147,16 +147,20 @@ class QueueManagerTest extends TestCase
         $this->manager->addExecutor($executor);
 
         $payload = ['data'];
+        $expectedPayload = $payload;
+        $expectedPayload['__rescheduleTime'] = PheanstalkInterface::DEFAULT_RESCHEDULE_TIME;
 
         $this->pheanstalk
             ->expects($this->once())
             ->method('putInTube')
-            ->with($action, json_encode($payload), PheanstalkInterface::DEFAULT_PRIORITY, PheanstalkInterface::DEFAULT_DELAY, PheanstalkInterface::DEFAULT_TTR)
+            ->with($action, json_encode($expectedPayload), PheanstalkInterface::DEFAULT_PRIORITY, PheanstalkInterface::DEFAULT_DELAY, PheanstalkInterface::DEFAULT_TTR)
             ->will($this->returnValue(1234))
         ;
 
         $this->assertEquals(1234, $this->manager->add($action, $payload));
     }
+
+
 
     public function testAddWithArguments()
     {
@@ -168,15 +172,18 @@ class QueueManagerTest extends TestCase
         $priority = 10;
         $delay    = 10;
         $ttr      = 1200;
+        $rescheduleTime = '60min';
+        $expectedPayload = $payload;
+        $expectedPayload['__rescheduleTime'] = '60min';
 
         $this->pheanstalk
             ->expects($this->once())
             ->method('putInTube')
-            ->with($action, json_encode($payload), $priority, $delay, $ttr)
+            ->with($action, json_encode($expectedPayload), $priority, $delay, $ttr)
             ->will($this->returnValue(1234))
         ;
 
-        $this->assertEquals(1234, $this->manager->add($action, $payload, $delay, $priority, $ttr));
+        $this->assertEquals(1234, $this->manager->add($action, $payload, $delay, $priority, $ttr,$rescheduleTime));
     }
 
     /**


### PR DESCRIPTION
Currently your the  QueueManage would try again with a hardcoded delay of 10 minutes.
With this patch, it would be allowed to have a custom delay-time for each job