### PR TITLE
Use the exact symfony requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,12 @@
   ],
   "require": {
     "php": ">=7.0",
-    "symfony/symfony": "^2.8|^3.0|^4.0",
+    "symfony/dependency-injection": "~2.8|~3.0|^4.0",
+    "symfony/config": "~2.8|~3.0|~4.0",
+    "symfony/http-kernel": "~2.8|~3.0|~4.0",
+    "symfony/console": "~2.8|~3.0|~4.0",
+    "symfony/options-resolver": "~2.8|~3.0|~4.0",
+    "symfony/event-dispatcher": "~2.8|~3.0|~4.0",
     "pda/pheanstalk": "^3.0"
   },
   "require-dev": {

--- a/src/TreeHouse/WorkerBundle/Command/ListCommand.php
+++ b/src/TreeHouse/WorkerBundle/Command/ListCommand.php
@@ -8,6 +8,7 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Terminal;
 use TreeHouse\WorkerBundle\QueueManager;
 
 class ListCommand extends Command
@@ -126,7 +127,7 @@ class ListCommand extends Command
             $output->write(sprintf("\033[%dA", $this->lineCount));
 
             // overwrite the complete table before rendering the new one
-            $width = $this->getApplication()->getTerminalDimensions()[0];
+            $width = (new Terminal())->getWidth();
             $lines = array_fill(0, $this->lineCount, str_pad('', $width, ' '));
             $output->writeln($lines);
 

--- a/src/TreeHouse/WorkerBundle/DependencyInjection/Configuration.php
+++ b/src/TreeHouse/WorkerBundle/DependencyInjection/Configuration.php
@@ -12,8 +12,8 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('tree_house_worker')->children();
+        $treeBuilder = new TreeBuilder('tree_house_worker');
+        $rootNode = $treeBuilder->getRootNode()->children();
 
         $rootNode
             ->scalarNode('pheanstalk')


### PR DESCRIPTION
Skeleton apps disable loading all symfony components. So instead of that we just require what is really needed.